### PR TITLE
Add complete? to Pour to determine when observer should fire

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,8 @@ group :test, :development do
   gem 'domino', '~> 0.4'
   gem 'database_cleaner'
   gem 'factory_girl_rails'
-  gem 'debugger'
+  # gem 'debugger'
+  gem 'timecop'
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,18 +55,11 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.6.1)
-    columnize (0.3.6)
     cookiejar (0.3.0)
     d3js-rails (3.0.0.1)
       railties (>= 3.0, < 5.0)
     daemons (1.1.9)
     database_cleaner (0.9.1)
-    debugger (1.5.0)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.2.0)
-    debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.2.0)
     diff-lcs (1.2.1)
     domino (0.4.0)
       capybara (>= 0.4.0)
@@ -107,8 +100,6 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.7.7)
-    launchy (2.2.0)
-      addressable (~> 2.3)
     mail (2.5.3)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
@@ -189,6 +180,7 @@ GEM
       rack (>= 1.0.0)
     thor (0.17.0)
     tilt (1.3.6)
+    timecop (0.6.1)
     treetop (1.4.12)
       polyglot
       polyglot (>= 0.3.1)
@@ -214,7 +206,6 @@ DEPENDENCIES
   coffee-rails (~> 3.2.1)
   d3js-rails
   database_cleaner
-  debugger
   domino (~> 0.4)
   factory_girl_rails
   faye
@@ -228,5 +219,6 @@ DEPENDENCIES
   rspec-rails (~> 2.0)
   sass-rails (~> 3.2.3)
   thin
+  timecop
   turbo-sprockets-rails3
   uglifier (>= 1.0.3)

--- a/app/models/pour.rb
+++ b/app/models/pour.rb
@@ -16,6 +16,10 @@ class Pour < ActiveRecord::Base
   scope :finished, where("finished_at IS NOT NULL")
   scope :non_guest, where("user_id > 0")
 
+  def complete?
+    finished_at.nil? ? false : (Time.now - finished_at) > Setting.pour_timeout
+  end
+
   private
 
   def calculate_duration

--- a/app/observers/pour_observer.rb
+++ b/app/observers/pour_observer.rb
@@ -13,7 +13,7 @@ class PourObserver < ActiveRecord::Observer
   end
 
   def send_pour_update(pour)
-    return true if Setting.faye_url.blank? || pour.volume.to_f <= 0.1
+    return true if Setting.faye_url.blank? || pour.volume.to_f <= 0.1 || pour.complete?
 
     update_type = (pour.finished_at ? :complete : :update)
 

--- a/spec/models/pour_spec.rb
+++ b/spec/models/pour_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Pour do
+  describe "#complete?" do
+    before :each do
+      Timecop.freeze(Time.current)
+    end
+
+    after do
+      Timecop.return
+    end
+
+    it 'returns true if the pour is completed and the current time is after the pour timeout' do
+      pour = FactoryGirl.create(:pour, finished_at: Time.current)
+      Timecop.travel(Time.current + Setting.pour_timeout + 1)
+      expect(pour.complete?).to eq(true)
+    end
+
+    it 'returns false if the pour is completed and the current time is within the pour timeout' do
+      pour = FactoryGirl.create(:pour, finished_at: Time.current)
+      expect(pour.complete?).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
Pour updates that occur after the physical pour event (like edits or deletes) should not fire off a Faye message as the UI would treat this as a new pour. 
