### PR TITLE
Add basic authentication for admin actions

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,2 +1,9 @@
 class AdminController < ApplicationController
+  http_basic_authenticate_with name: "bender", password: Setting.admin_password, if: :needs_authetication?
+
+  private
+
+  def needs_authetication?
+    Setting.admin_password.present?
+  end
 end

--- a/lib/setting.rb
+++ b/lib/setting.rb
@@ -33,6 +33,10 @@ module Setting
     settings['mruby_bin']
   end
 
+  def self.admin_password
+    settings['admin_password']
+  end
+
   def self.settings
     @settings ||= YAML.load_file(Rails.root.join('config', 'settings.yml'))
   end


### PR DESCRIPTION
Worksighted would like authentication for admin actions such as managing users.

[[Finishes #149859218]](https://www.pivotaltracker.com/story/show/149859218)