### PR TITLE
API Refactor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem 'active_model_serializers'
 gem 'bigdecimal'
 gem 'kaminari'
 gem 'rails-observers'
-gem 'responders'
 
 gem 'oj'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,9 +279,6 @@ GEM
     raindrops (0.20.0)
     rake (13.0.6)
     regexp_parser (2.2.1)
-    responders (3.0.1)
-      actionpack (>= 5.0)
-      railties (>= 5.0)
     rexml (3.2.5)
     rspec-core (3.11.0)
       rspec-support (~> 3.11.0)
@@ -356,7 +353,6 @@ DEPENDENCIES
   rails (~> 7.0.1)
   rails-observers
   raindrops
-  responders
   rspec-rails
   rubocop
   stackprof

--- a/app/controllers/activity_controller.rb
+++ b/app/controllers/activity_controller.rb
@@ -1,16 +1,14 @@
 class ActivityController < ApplicationController
-  respond_to :json
-
   def recent
     pours = Pour.where('volume IS NOT NULL').order('created_at desc').limit(params[:limit] || 10)
 
-    respond_with append_data(pours)
+    render json: append_data(pours).to_json
   end
 
   def user_recent
     pours = Pour.where('volume IS NOT NULL AND user_id = ?', params[:user_id]).order('created_at desc').limit(params[:limit] || 10)
 
-    respond_with append_data(pours)
+    render json: append_data(pours).to_json
   end
 
   def append_data(pours)

--- a/app/controllers/admin/beer_taps_controller.rb
+++ b/app/controllers/admin/beer_taps_controller.rb
@@ -1,17 +1,10 @@
 class Admin::BeerTapsController < ApplicationController
-  respond_to :html, :json
-
   def index
     @beer_taps = BeerTap.order(:display_order)
-    respond_to do |wants|
-      wants.html
-      wants.json { render json: @beer_taps.preload(:active_keg) }
-    end
   end
 
   def show
     @beer_tap = BeerTap.find(params[:id])
-    respond_with @beer_tap
   end
 
   def new

--- a/app/controllers/admin/kegs_controller.rb
+++ b/app/controllers/admin/kegs_controller.rb
@@ -1,19 +1,14 @@
 class Admin::KegsController < ApplicationController
-  respond_to :html, :json
-
   def index
     @kegs = Keg.order('started_at DESC NULLS FIRST')
-    respond_with @kegs
   end
 
   def show
     @keg = Keg.find(params[:id])
-    respond_with @keg
   end
 
   def new
     @keg = Keg.new
-    respond_with @keg
   end
 
   def create
@@ -27,7 +22,6 @@ class Admin::KegsController < ApplicationController
 
   def edit
     @keg = Keg.find(params[:id])
-    respond_with @keg
   end
 
   def update

--- a/app/controllers/admin/metrics_controller.rb
+++ b/app/controllers/admin/metrics_controller.rb
@@ -1,7 +1,5 @@
 class Admin::MetricsController < ApplicationController
-  respond_to :json
-
   def achievements
-    respond_with Achievement.all
+    render json: Achievement.all.to_json
   end
 end

--- a/app/controllers/admin/pours_controller.rb
+++ b/app/controllers/admin/pours_controller.rb
@@ -1,10 +1,7 @@
 class Admin::PoursController < ApplicationController
-  respond_to :html, :json
-
   def index
     @keg = Keg.find(params[:keg_id])
     @pours = @keg.pours.for_listing.page(params[:page])
-    respond_with @pours
   end
 
   def destroy

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -1,8 +1,5 @@
 class Admin::SettingsController < ApplicationController
-  respond_to :json
-
   def index
     @settings = Setting.settings
-    respond_with @settings
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -14,13 +14,8 @@ class Admin::UsersController < ApplicationController
     @user.attributes = user_params
 
     if @user.save
-      respond_to do |format|
-        format.json { respond_with @user }
-        format.html do
-          flash[:success] = 'User updated'
-          redirect_to admin_users_path
-        end
-      end
+      flash[:success] = 'User updated'
+      redirect_to admin_users_path
     else
       render :edit
     end
@@ -39,13 +34,8 @@ class Admin::UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      respond_to do |format|
-        format.json { respond_with @user }
-        format.html do
-          flash[:success] = 'User created'
-          redirect_to admin_users_path
-        end
-      end
+      flash[:success] = 'User created'
+      redirect_to admin_users_path
     else
       render :new
     end

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,0 +1,2 @@
+class API::ApplicationController < ApplicationController
+end

--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -1,6 +1,6 @@
 module API
   module V1
-    class AuthController < APIController
+    class AuthController < ApplicationController
       def create
         user = User.find_by(rfid: auth_params)
 

--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -1,6 +1,6 @@
-module Api
+module API
   module V1
-    class AuthController < ApiController
+    class AuthController < APIController
       def create
         user = User.find_by(rfid: auth_params)
 

--- a/app/controllers/api/v1/beer_taps_controller.rb
+++ b/app/controllers/api/v1/beer_taps_controller.rb
@@ -1,6 +1,6 @@
 module API
   module V1
-    class BeerTapsController < APIController
+    class BeerTapsController < ApplicationController
       def index
         beer_taps = BeerTap.preload(:active_keg).order(:display_order)
 

--- a/app/controllers/api/v1/beer_taps_controller.rb
+++ b/app/controllers/api/v1/beer_taps_controller.rb
@@ -1,6 +1,6 @@
-module Api
+module API
   module V1
-    class BeerTapsController < ApiController
+    class BeerTapsController < APIController
       def index
         beer_taps = BeerTap.preload(:active_keg).order(:display_order)
 

--- a/app/controllers/api/v1/kegs_controller.rb
+++ b/app/controllers/api/v1/kegs_controller.rb
@@ -1,0 +1,16 @@
+module API
+  module V1
+    class KegsController < ApplicationController
+      def index
+        @kegs = Keg.order('started_at DESC NULLS FIRST')
+        @kegs = @kegs.where(active: true) if params[:active] == 'true'
+        render json: @kegs.preload(:beer_tap).as_json(include: :beer_tap)
+      end
+
+      def show
+        @keg = Keg.find(params[:id])
+        render json: @keg.as_json(include: :beer_tap)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/pours_controller.rb
+++ b/app/controllers/api/v1/pours_controller.rb
@@ -1,6 +1,6 @@
 module API
   module V1
-    class PoursController < APIController
+    class PoursController < ApplicationController
       def index
         @pours = Pour.for_listing.except(:includes).
           between_dates(start_time: start_time, end_time: end_time)

--- a/app/controllers/api/v1/pours_controller.rb
+++ b/app/controllers/api/v1/pours_controller.rb
@@ -14,16 +14,16 @@ module API
         when "by_beer"
           data = pours.joins(:keg).where.not(started_at: nil).
             group("kegs.name, pour_date").order("kegs.name, pour_date").
-            pluck("kegs.name AS name, date_trunc('day', pours.started_at::TIMESTAMPTZ AT TIME ZONE '#{Time.zone.tzinfo.canonical_identifier}') AS pour_date, count(pours.id) AS pour_count").
+            pluck(Arel.sql("kegs.name AS name, date_trunc('day', pours.started_at::TIMESTAMPTZ AT TIME ZONE '#{Time.zone.tzinfo.canonical_identifier}') AS pour_date, count(pours.id) AS pour_count")).
             each.with_object({}) do |pour, out|
               (out[pour[0]] ||= []) << [pour[1].to_date, pour[2]]
             end
 
-          render json: Oj.dump(data, mode: :compat)
+          render json: Oj.dump(data.as_json, mode: :compat)
         when "by_user"
           data = pours.joins(:user).
             group("users.name, users.email").select("users.name", "users.email, SUM(pours.volume) AS volume")
-          render json: Oj.dump(data, mode: :compat)
+          render json: Oj.dump(data.as_json, mode: :compat)
         end
       end
 

--- a/app/controllers/api/v1/pours_controller.rb
+++ b/app/controllers/api/v1/pours_controller.rb
@@ -1,6 +1,6 @@
-module Api
+module API
   module V1
-    class PoursController < ApiController
+    class PoursController < APIController
       def index
         @pours = Pour.for_listing.except(:includes).
           between_dates(start_time: start_time, end_time: end_time)

--- a/app/controllers/api/v1/stats_controller.rb
+++ b/app/controllers/api/v1/stats_controller.rb
@@ -1,6 +1,6 @@
-module Api
+module API
   module V1
-    class StatsController < ApiController
+    class StatsController < APIController
       def index
         user = User.where("id = ? OR rfid = ?", params[:user_id], params[:user_rfid]).first!
         render json: Oj.dump(user.stats, mode: :compat)

--- a/app/controllers/api/v1/stats_controller.rb
+++ b/app/controllers/api/v1/stats_controller.rb
@@ -1,6 +1,6 @@
 module API
   module V1
-    class StatsController < APIController
+    class StatsController < ApplicationController
       def index
         user = User.where("id = ? OR rfid = ?", params[:user_id], params[:user_rfid]).first!
         render json: Oj.dump(user.stats, mode: :compat)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -2,7 +2,7 @@ module API
   module V1
     class UsersController < ApplicationController
       def index
-        @users = User.all
+        @users = User.active
 
         render json: Oj.dump(@users.as_json, mode: :compat)
       end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,17 @@
+module API
+  module V1
+    class UsersController < ApplicationController
+      def index
+        @users = User.all
+
+        render json: Oj.dump(@users.as_json, mode: :compat)
+      end
+
+      def show
+        # Looks up via id or rfid. Previous API used user_rfid.
+        @user = User.where(id: params[:id]).or(User.where(rfid: params[:id])).sole
+        render json: Oj.dump(@user.as_json, mode: :compat)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -12,6 +12,22 @@ module API
         @user = User.where(id: params[:id]).or(User.where(rfid: params[:id])).sole
         render json: Oj.dump(@user.as_json, mode: :compat)
       end
+
+      def create
+        @user = User.new(user_params)
+
+        if @user.save
+          render json: Oj.dump(@user.as_json, mode: :compat), status: :created
+        else
+          render json: Oj.dump(@user.errors.to_json, mode: :compat), status: :unprocessible_entity
+        end
+      end
+
+      protected
+
+      def user_params
+        params.require(:user).permit(:name, :email, :rfid)
+      end
     end
   end
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,2 +1,0 @@
-class APIController < ApplicationController
-end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,2 +1,2 @@
-class ApiController < ApplicationController
+class APIController < ApplicationController
 end

--- a/app/controllers/kegs_controller.rb
+++ b/app/controllers/kegs_controller.rb
@@ -1,17 +1,10 @@
 class KegsController < ApplicationController
-  respond_to :html, :json
-
   def index
     @kegs = Keg.order('started_at DESC NULLS FIRST')
     @kegs = @kegs.where(active: true) if params[:active] == 'true'
-    respond_to do |wants|
-      wants.html
-      wants.json { render json: @kegs.preload(:beer_tap) }
-    end
   end
 
   def show
     @keg = Keg.find(params[:id])
-    respond_with @keg
   end
 end

--- a/app/controllers/pours_controller.rb
+++ b/app/controllers/pours_controller.rb
@@ -1,10 +1,6 @@
 class PoursController < ApplicationController
-  respond_to :html, :json
-
   def index
     @pours = Pour.for_listing.page(params[:page])
-
-    respond_with @pours
   end
 
   def new
@@ -21,16 +17,12 @@ class PoursController < ApplicationController
     tap = BeerTap.find(params[:beer_tap_id])
     pour = tap.active_keg.start_pour(user)
 
-    respond_to do |format|
-      format.json { respond_with pour }
-      format.html { redirect_to pour }
-    end
+    redirect_to pour
   end
 
   def show
     @pour = Pour.find(params[:id])
     redirect_to root_path if @pour.finished_at
-    respond_with @pour
   end
 
   def edit
@@ -45,10 +37,7 @@ class PoursController < ApplicationController
     else
       pour.update(pour_params)
     end
-    respond_to do |format|
-      format.json { respond_with pour }
-      format.html { redirect_to(params[:back_to] || root_path) }
-    end
+    redirect_to(params[:back_to] || root_path)
   end
 
   def volume

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,15 +1,10 @@
 class UsersController < ApplicationController
-  respond_to :html, :json
-
   def index
     @users = User.active
-
-    respond_with @users
   end
 
   def show
     @user = User.where("id = ? OR rfid = ?", params[:id], params[:user_rfid]).first!
-    respond_with @user
   end
 
   def new
@@ -19,13 +14,8 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      respond_to do |format|
-        format.json { respond_with @user }
-        format.html do
-          flash[:success] = 'User created'
-          redirect_to root_path
-        end
-      end
+      flash[:success] = 'User created'
+      redirect_to root_path
     else
       render :new
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   respond_to :html, :json
 
   def index
-    @users = User.all
+    @users = User.active
 
     respond_with @users
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@ class User < ActiveRecord::Base
 
   has_many :pours
 
+  scope :active, -> { where(hidden: false) }
+
   def self.guest
     find_by(id: 0) || new(id: 0, name: 'Guest')
   end

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -13,6 +13,9 @@
   <%= f.label :credits, "Fluid oz" %>
   <%= f.number_field :credits, step: :any %>
 
+  <%= f.label :hidden, "Hide" %>
+  <%= f.checkbox :hidden %>
+
   <div class="form-actions">
     <%= f.submit 'Save', :class => 'btn btn-primary' %>
     <%= link_to 'Cancel', :back, :cliass => 'btn btn-default' %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -22,6 +22,7 @@
       <td><%= user.email %></td>
       <td><%= user.rfid %></td>
       <td><%= user.credits %></td>
+      <td><%= "Hidden" if user.hidden? %></td>
       <td>
         <%= link_to 'Edit', edit_admin_user_path(user) %>
       </td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -7,6 +7,6 @@
 
 <ul class="unstyled">
   <% @users.each do |user| %>
-    <li><%= link_to user.name, user %>
+    <li><%= user.name %>
   <% end %>
 </ul>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -12,5 +12,6 @@
 
 # These inflection rules are supported but not enabled by default:
 ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'API'
   inflect.acronym 'GPIO'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :auth, only: [:create]
       resources :taps, only: [:index], controller: "beer_taps"
+      resources :kegs, only: [:index]
       resources :pours, only: [:index, :show]
       resources :users, only: [:index, :show, :create] do
         resources :stats, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
       resources :auth, only: [:create]
       resources :taps, only: [:index], controller: "beer_taps"
       resources :pours, only: [:index, :show]
-      resources :users, only: [] do
+      resources :users, only: [:index, :show] do
         resources :stats, only: [:index]
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
       resources :auth, only: [:create]
       resources :taps, only: [:index], controller: "beer_taps"
       resources :pours, only: [:index, :show]
-      resources :users, only: [:index, :show] do
+      resources :users, only: [:index, :show, :create] do
         resources :stats, only: [:index]
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :auth, only: [:create]
       resources :taps, only: [:index], controller: "beer_taps"
-      resources :kegs, only: [:index]
+      resources :kegs, only: [:index, :show]
       resources :pours, only: [:index, :show]
       resources :users, only: [:index, :show, :create] do
         resources :stats, only: [:index]

--- a/db/migrate/20220310184627_add_hidden_to_users.rb
+++ b/db/migrate/20220310184627_add_hidden_to_users.rb
@@ -1,0 +1,6 @@
+class AddHiddenToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :hidden, :boolean, default: false, null: false
+    add_index :users, :hidden
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2017_10_03_222034) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_10_184627) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -92,6 +92,8 @@ ActiveRecord::Schema[7.0].define(version: 2017_10_03_222034) do
     t.string "rfid"
     t.decimal "credits"
     t.datetime "last_pour_at", precision: nil
+    t.boolean "hidden", default: false, null: false
+    t.index ["hidden"], name: "index_users_on_hidden"
   end
 
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :user do
     sequence(:name)  {|n| "John #{n}" }
     sequence(:email) {|n| "user#{n}@example.com" }
+    sequence(:rfid)  {|n| "rfid-#{n}" }
   end
 end

--- a/spec/requests/api/kegs_spec.rb
+++ b/spec/requests/api/kegs_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "Kegs API" do
+  describe "GET /api/vi/kegs" do
+    let!(:keg) { FactoryBot.create(:keg, name: "PBR") }
+
+    it "returns all active users as json" do
+      get "/api/v1/kegs"
+
+      expect(response.status).to eq(200)
+      json_response = JSON.parse(response.body)
+      expect(json_response.map{|u| u["name"]}).to include("PBR")
+      tap_names = json_response.map{|u| u["beer_tap"]}.flatten.map{|t| t["name"] }
+      expect(tap_names).to include(keg.beer_tap.name)
+    end
+  end
+end

--- a/spec/requests/api/kegs_spec.rb
+++ b/spec/requests/api/kegs_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Kegs API" do
   describe "GET /api/vi/kegs" do
     let!(:keg) { FactoryBot.create(:keg, name: "PBR") }
 
-    it "returns all active users as json" do
+    it "returns all active kegs as json" do
       get "/api/v1/kegs"
 
       expect(response.status).to eq(200)
@@ -12,6 +12,18 @@ RSpec.describe "Kegs API" do
       expect(json_response.map{|u| u["name"]}).to include("PBR")
       tap_names = json_response.map{|u| u["beer_tap"]}.flatten.map{|t| t["name"] }
       expect(tap_names).to include(keg.beer_tap.name)
+    end
+  end
+
+  describe "GET /api/vi/kegs/:id" do
+    let!(:keg) { FactoryBot.create(:keg, name: "PBR") }
+
+    it "returns the keg as json" do
+      get "/api/v1/kegs/#{keg.id}"
+
+      expect(response.status).to eq(200)
+      json_response = JSON.parse(response.body)
+      expect(json_response["name"]).to eq("PBR")
     end
   end
 end

--- a/spec/requests/api/pours_spec.rb
+++ b/spec/requests/api/pours_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe "Pours API" do
+  describe "GET /api/vi/pours" do
+    let!(:pour) { FactoryBot.create(:pour) }
+
+    it "returns pours as json" do
+      get "/api/v1/pours"
+
+      expect(response.status).to eq(200)
+      json_response = JSON.parse(response.body)
+      expect(json_response.map{|u| u["volume"]}).to include(pour.volume.to_s)
+    end
+
+    it "returns pours for a date range as json" do
+      pour_in = FactoryBot.create(:pour, created_at: 15.minutes.ago)
+      pour_out = FactoryBot.create(:pour, created_at: 5.minutes.ago)
+
+      get "/api/v1/pours", params: {start_time: 20.minutes.ago, end_time: 10.minutes.ago}
+
+      expect(response.status).to eq(200)
+      json_response = JSON.parse(response.body)
+      expect(json_response.map{|u| u["volume"]}).to include(pour_in.volume.to_s)
+      expect(json_response.map{|u| u["volume"]}).not_to include(pour_out.volume.to_s)
+    end
+  end
+
+  describe "sorted pours" do
+    let!(:pour_in) { FactoryBot.create(:pour, created_at: 15.minutes.ago) }
+    let!(:pour_out) { FactoryBot.create(:pour, created_at: 5.minutes.ago) }
+
+    describe "GET /api/vi/pours/by_beer" do
+
+      it "returns pours by beer as json" do
+        get "/api/v1/pours/by_beer", params: {start_time: 20.minutes.ago, end_time: 10.minutes.ago}
+
+        expect(response.status).to eq(200)
+        json_response = JSON.parse(response.body)
+        expect(json_response.map{|u| u.first}).to include(pour_in.keg.name)
+        expect(json_response.map{|u| u.first}).not_to include(pour_out.keg.name)
+      end
+    end
+
+    describe "GET /api/vi/pours/by_user" do
+      it "returns pours by user as json" do
+        get "/api/v1/pours/by_user", params: {start_time: 20.minutes.ago, end_time: 10.minutes.ago}
+
+        expect(response.status).to eq(200)
+        json_response = JSON.parse(response.body)
+        expect(json_response.map{|u| u["email"]}).to include(pour_in.user.email)
+        expect(json_response.map{|u| u["email"]}).not_to include(pour_out.user.email)
+      end
+    end
+  end
+end

--- a/spec/requests/api/stats_spec.rb
+++ b/spec/requests/api/stats_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "User Stats API" do
+  describe "GET /api/vi/users/:id/stats" do
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:pour) { FactoryBot.create(:pour, user: user) }
+
+    it "returns the user's stats as json" do
+      get "/api/v1/users/#{user.id}/stats"
+
+      expect(response.status).to eq(200)
+      json_response = JSON.parse(response.body)
+      expect(json_response["email"]).to eq(user.email)
+      expect(json_response["recent_pours"].first).to include(pour.volume.to_s)
+    end
+  end
+end

--- a/spec/requests/api/taps_spec.rb
+++ b/spec/requests/api/taps_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "Taps API" do
+  describe "GET /api/vi/taps" do
+    let!(:keg) { FactoryBot.create(:keg) }
+
+    it "returns all active taps as json" do
+      get "/api/v1/taps"
+
+      expect(response.status).to eq(200)
+      json_response = JSON.parse(response.body)
+      expect(json_response.map{|u| u["name"]}).to include(keg.beer_tap.name)
+    end
+  end
+end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -3,12 +3,15 @@ require "rails_helper"
 RSpec.describe "User API" do
   describe "GET /api/vi/users" do
     let!(:user) { FactoryBot.create(:user) }
-    it "returns all users as json" do
+    let!(:hidden_user) { FactoryBot.create(:user, hidden: true) }
+
+    it "returns all active users as json" do
       get "/api/v1/users"
 
       expect(response.status).to eq(200)
       json_response = JSON.parse(response.body)
       expect(json_response.map{|u| u["id"]}).to include(user.id)
+      expect(json_response.map{|u| u["id"]}).not_to include(hidden_user.id)
     end
 
     it "returns a single user as json by id" do
@@ -17,6 +20,14 @@ RSpec.describe "User API" do
       expect(response.status).to eq(200)
       json_response = JSON.parse(response.body)
       expect(json_response["id"]).to equal(user.id)
+    end
+
+    it "returns a single user as json by id even if hidden" do
+      get "/api/v1/users/#{hidden_user.id}"
+
+      expect(response.status).to eq(200)
+      json_response = JSON.parse(response.body)
+      expect(json_response["id"]).to equal(hidden_user.id)
     end
 
     it "returns a single user as json by rfid" do

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe "User API" do
       expect(json_response.map{|u| u["id"]}).to include(user.id)
       expect(json_response.map{|u| u["id"]}).not_to include(hidden_user.id)
     end
+  end
+
+  describe "GET /api/v1/users/:id" do
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:hidden_user) { FactoryBot.create(:user, hidden: true) }
 
     it "returns a single user as json by id" do
       get "/api/v1/users/#{user.id}"
@@ -36,6 +41,17 @@ RSpec.describe "User API" do
       expect(response.status).to eq(200)
       json_response = JSON.parse(response.body)
       expect(json_response["id"]).to equal(user.id)
+    end
+  end
+
+  describe "POST /api/v1/users" do
+    it "creates and returns user as json" do
+      post "/api/v1/users", params: {user: {name: "Test User", email: ""}}
+
+      expect(response.status).to eq(201)
+      json_response = JSON.parse(response.body)
+      expect(json_response["id"]).not_to be(nil)
+      expect(json_response["name"]).to eq("Test User")
     end
   end
 end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "User API" do
+  describe "GET /api/vi/users" do
+    let!(:user) { FactoryBot.create(:user) }
+    it "returns all users as json" do
+      get "/api/v1/users"
+
+      expect(response.status).to eq(200)
+      json_response = JSON.parse(response.body)
+      expect(json_response.map{|u| u["id"]}).to include(user.id)
+    end
+
+    it "returns a single user as json by id" do
+      get "/api/v1/users/#{user.id}"
+
+      expect(response.status).to eq(200)
+      json_response = JSON.parse(response.body)
+      expect(json_response["id"]).to equal(user.id)
+    end
+
+    it "returns a single user as json by rfid" do
+      get "/api/v1/users/#{user.rfid}"
+
+      expect(response.status).to eq(200)
+      json_response = JSON.parse(response.body)
+      expect(json_response["id"]).to equal(user.id)
+    end
+  end
+end


### PR DESCRIPTION
We had our API split between regular and namespaced controllers. This moves them all under the namespace. 

Added some more tests.

This allows us to remove the `responders` gem, which we had to add in the upgrade, as it was extracted from Rails. 