### PR TITLE
Add armv7l-linux-eabihf to lockfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,7 @@ GEM
     method_source (1.0.0)
     mini_histogram (0.3.1)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.0)
     minitest (5.15.0)
     multi_json (1.15.0)
     net-imap (0.2.3)
@@ -196,6 +197,9 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.6)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.13.6-aarch64-linux)
       racc (~> 1.4)
     nokogiri (1.13.6-arm64-darwin)
@@ -314,6 +318,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-21
+  armv7l-linux-eabihf
   x86_64-darwin-19
   x86_64-linux
 


### PR DESCRIPTION
In order to properly bundle install on the pi the lock file needs this additional platform specified